### PR TITLE
Fix pokepic for variant Pokémon

### DIFF
--- a/bank_ends.txt
+++ b/bank_ends.txt
@@ -1,13 +1,13 @@
 Bank $00: $37d4 ($082c)
-Bank $01: $76f1 ($090f)
+Bank $01: $76f8 ($0908)
 Bank $02: $7c8c ($0374)
-Bank $03: $7675 ($098b)
+Bank $03: $7679 ($0987)
 Bank $04: $7b30 ($04d0)
 Bank $05: $74db ($0b25)
 Bank $06: $7446 ($0bba)
 Bank $07: $6fb4 ($104c)
 Bank $08: $7043 ($0fbd)
-Bank $09: $653c ($1ac4)
+Bank $09: $6541 ($1abf)
 Bank $0a: $64e1 ($1b1f)
 Bank $0b: $6550 ($1ab0)
 Bank $0c: $692b ($16d5)
@@ -112,9 +112,9 @@ Bank $6e: $5ae0 ($2520)
 Bank $6f: $4ca9 ($3357)
 Bank $70: $5ad4 ($252c)
 Bank $71: $53be ($2c42)
-Bank $72: $6b64 ($149c)
+Bank $72: $6b92 ($146e)
 Bank $73: $5b68 ($2498)
-Bank $74: $5a64 ($259c)
+Bank $74: $5a65 ($259b)
 Bank $75: $4000 ($4000)
 Bank $76: $4000 ($4000)
 Bank $77: $52f0 ($2d10)
@@ -192,7 +192,7 @@ Bank $1e has $2867 bytes of free space
 Bank $2b has $27af bytes of free space
 Bank $2a has $2756 bytes of free space
 Bank $5e has $2611 bytes of free space
-Bank $74 has $259c bytes of free space
+Bank $74 has $259b bytes of free space
 Bank $70 has $252c bytes of free space
 Bank $6e has $2520 bytes of free space
 Bank $60 has $24ec bytes of free space
@@ -213,12 +213,12 @@ Bank $38 has $1c68 bytes of free space
 Bank $0a has $1b1f bytes of free space
 Bank $51 has $1aff bytes of free space
 Bank $4c has $1adc bytes of free space
-Bank $09 has $1ac4 bytes of free space
+Bank $09 has $1abf bytes of free space
 Bank $0b has $1ab0 bytes of free space
 Bank $4f has $1869 bytes of free space
 Bank $0c has $16d5 bytes of free space
 Bank $4d has $1634 bytes of free space
-Bank $72 has $149c bytes of free space
+Bank $72 has $146e bytes of free space
 Bank $37 has $1455 bytes of free space
 Bank $4e has $13d2 bytes of free space
 Bank $52 has $12f1 bytes of free space
@@ -237,8 +237,8 @@ Bank $10 has $0b21 bytes of free space
 Bank $53 has $0ac0 bytes of free space
 Bank $14 has $0a75 bytes of free space
 Bank $5a has $0a72 bytes of free space
-Bank $03 has $098b bytes of free space
-Bank $01 has $090f bytes of free space
+Bank $03 has $0987 bytes of free space
+Bank $01 has $0908 bytes of free space
 Bank $59 has $08ac bytes of free space
 Bank $00 has $082c bytes of free space
 Bank $0d has $0628 bytes of free space
@@ -256,4 +256,4 @@ Bank $3d has $0117 bytes of free space
 Bank $31 has $0080 bytes of free space
 Bank $30 has $0040 bytes of free space
 
-Free space: 1257423/2097152 (59.96%)
+Free space: 1257360/2097152 (59.96%)

--- a/engine/pokepic.asm
+++ b/engine/pokepic.asm
@@ -10,6 +10,8 @@ Pokepic:: ; 244e3
 	ld [hBGMapMode], a
 	ld a, [CurPartySpecies]
 	ld [CurSpecies], a
+	ld a, 1
+	ld [MonVariant], a
 	call GetBaseData
 	ld de, VTiles1
 	predef GetFrontpic

--- a/roms.md5
+++ b/roms.md5
@@ -1,1 +1,1 @@
-9c440f9f38f77ede0d69184e392ae526 *pokeorange.gbc
+5fe7872e2ba7b39c8e04b1660ed66115 *pokeorange.gbc


### PR DESCRIPTION
Free space: 1257360/2097152 (59.96%)