### PR TITLE
Fix Mt. Navel whiteout/Dig/Escape Rope bug

### DIFF
--- a/bank_ends.txt
+++ b/bank_ends.txt
@@ -63,7 +63,7 @@ Bank $3d: $7ee9 ($0117)
 Bank $3e: $4f2f ($30d1)
 Bank $3f: $5143 ($2ebd)
 Bank $40: $4000 ($4000)
-Bank $41: $4f2f ($30d1)
+Bank $41: $4f34 ($30cc)
 Bank $42: $61c5 ($1e3b)
 Bank $43: $4892 ($376e)
 Bank $44: $4000 ($4000)
@@ -110,7 +110,7 @@ Bank $6c: $4a7f ($3581)
 Bank $6d: $4000 ($4000)
 Bank $6e: $5ae0 ($2520)
 Bank $6f: $4cc1 ($333f)
-Bank $70: $5ad2 ($252e)
+Bank $70: $5ad3 ($252d)
 Bank $71: $4fe3 ($301d)
 Bank $72: $6bbc ($1444)
 Bank $73: $5b68 ($2498)
@@ -175,7 +175,7 @@ Bank $6f has $333f bytes of free space
 Bank $26 has $3175 bytes of free space
 Bank $1b has $30fc bytes of free space
 Bank $3e has $30d1 bytes of free space
-Bank $41 has $30d1 bytes of free space
+Bank $41 has $30cc bytes of free space
 Bank $1a has $3057 bytes of free space
 Bank $71 has $301d bytes of free space
 Bank $1f has $2f0d bytes of free space
@@ -188,7 +188,7 @@ Bank $16 has $287a bytes of free space
 Bank $1e has $27e4 bytes of free space
 Bank $5e has $2611 bytes of free space
 Bank $74 has $259b bytes of free space
-Bank $70 has $252e bytes of free space
+Bank $70 has $252d bytes of free space
 Bank $6e has $2520 bytes of free space
 Bank $60 has $24ec bytes of free space
 Bank $73 has $2498 bytes of free space
@@ -256,4 +256,4 @@ Bank $19 has $0074 bytes of free space
 Bank $30 has $0040 bytes of free space
 Bank $21 has $002c bytes of free space
 
-Free space: 1201720/2097152 (57.30%)
+Free space: 1201714/2097152 (57.30%)

--- a/engine/warp_connection.asm
+++ b/engine/warp_connection.asm
@@ -174,10 +174,13 @@ LoadWarpData: ; 1046c6
 	call GetAnyMapPermission
 	call CheckIndoorMap
 	ret nz
-	ld a, [wPrevMapGroup]
-	jr nz, .not_mt_moon_or_tin_tower
-	ld a, [wPrevMapNumber]
-.not_mt_moon_or_tin_tower
+	ld a, [wNextMapGroup]
+	cp GROUP_MT_NAVEL_2F
+	jr nz, .not_to_mt_navel_2f
+	ld a, [wNextMapNumber]
+	cp MAP_MT_NAVEL_2F
+	ret z
+.not_to_mt_navel_2f
 	ld a, [wPrevWarp]
 	ld [wDigWarp], a
 	ld a, [wPrevMapGroup]

--- a/roms.md5
+++ b/roms.md5
@@ -1,1 +1,1 @@
-922a97277158134dc82f06807cc9b203 *pokeorange.gbc
+73548eea7bcfafa65dfa3ff901af41f7 *pokeorange.gbc

--- a/text/common_3.asm
+++ b/text/common_3.asm
@@ -235,7 +235,7 @@ UnknownText_0x1c0a4e::
 	text "<PLAYER> is out of"
 	line "useable #MON!"
 
-	para "<PLAYER> whited"
+	para "<PLAYER> blacked"
 	line "out!"
 	done
 


### PR DESCRIPTION
Also, "whited out" (Gen 2) → "blacked out" (Gen 1 and 6+7)