### PR TITLE
New Linux instructions in INSTALL.MD to build with rgbds 0.5.2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,6 @@ cd rgbds
 make
 
 cd ../
-make
 ```
 
 To build **pokeorange.gbc**:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -30,16 +30,20 @@ make
 # Linux
 
 ```bash
-sudo apt-get install make gcc python git bison
-
-git clone https://github.com/rednex/rgbds.git
-cd rgbds
-git checkout v0.2.5
-sudo make install
-cd ..
+sudo apt-get install make gcc python3 python-is-python3 git bison
 
 git clone https://github.com/PiaCarrot/pokeorange.git
 cd pokeorange
+
+wget https://github.com/gbdev/rgbds/archive/refs/tags/v0.5.2.tar.gz
+tar -xvzf v0.5.2.tar.gz
+rm v0.5.2.tar.gz
+mv rgbds-0.5.2/ rgbds
+cd rgbds
+make
+
+cd ../
+make
 ```
 
 To build **pokeorange.gbc**:


### PR DESCRIPTION
This proposed change aims to correct the previous installation instructions for Linux. Previously, rgbds 0.2.5 was used and installed on the user's machine. Version 0.5.2 is now used, as it is required to build pokeorange. With this new build method, rgbds is not installed directly on the machine, allowing the user to have a more recent version installed for other projects (like building pokecrystal with version 0.9.2 for example). I tested the instructions on Linux Mint 22.1